### PR TITLE
Disable exceptions at PHP 8.1

### DIFF
--- a/mysql.php
+++ b/mysql.php
@@ -29,6 +29,9 @@ if (!extension_loaded('mysql') && !function_exists('mysql_connect')) {
 	define('MYSQL_NUM', MYSQLI_NUM);
 	define('MYSQL_BOTH', MYSQLI_BOTH);
 
+	// Disable exceptions at PHP 8.1
+	mysqli_report(MYSQLI_REPORT_OFF);
+
 	// Will contain the link identifier
 	$__MYSQLI_WRAPPER_LINK = null;
 


### PR DESCRIPTION
Quote from the [manual](https://www.php.net/manual/en/mysqli-driver.report-mode.php):

> As of PHP 8.1.0, the default setting is `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`.
> Previously, it was `MYSQLI_REPORT_OFF`.

Without this commit every failed query will throw a [mysqli_sql_exception](https://www.php.net/manual/en/class.mysqli-sql-exception.php) and this will break legacy code which is expecting `false` as return value from certain functions.

With this change it's still possible to override the reporting mode after including this wrapper. 🤓